### PR TITLE
Added null safety to trajectory autos

### DIFF
--- a/src/main/java/frc/robot/commands/auto/DriveToCargo.java
+++ b/src/main/java/frc/robot/commands/auto/DriveToCargo.java
@@ -34,7 +34,7 @@ public class DriveToCargo extends SequentialCommandGroup {
         // movement needed in order to get to cargo
         Transform2d transform = photon.transformToTarget();
 
-        // if transform is null, instead transform to no movement
+        // if transform is null, instead do not move
         transform = (transform == null) ? new Transform2d() : transform;
 
         // desired end pose, generated from current location plus movement to target

--- a/src/main/java/frc/robot/subsystems/DriveSystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSystem.java
@@ -194,7 +194,7 @@ public class DriveSystem extends SubsystemBase {
    */
   public MecanumControllerCommand trajectoryCommand(Trajectory trajectory) {
     return new MecanumControllerCommand(
-      trajectory, // Path to follow
+      (trajectory != null) ? trajectory : new Trajectory(), // Path to follow
       this::getPose, // Current robot position
 
       KINEMATICS, // Distance from center of robot to each wheel

--- a/src/main/java/frc/robot/vision/Limelight.java
+++ b/src/main/java/frc/robot/vision/Limelight.java
@@ -161,6 +161,11 @@ public class Limelight implements Sendable{
         //Creates a transform2d for use by the limelight
         Transform2d limelightTransform2d = new Transform2d(limelightTranslation2d, limelightRotation2d);
 
+        // check if default values are returned
+        if (limelightTranslation2d.getX() == 0.0f && limelightTranslation2d.getY() == 0.0f) {
+            return null;
+        } 
+
         //Returns the limelight instance of Transform2d
         return limelightTransform2d;
     }
@@ -171,7 +176,11 @@ public class Limelight implements Sendable{
      * @return Horizontal distance converted to meters
      */
     public double getDistance() {
- 
+        // return negative 1 if a target is not present
+        if (!hasTargets()) {
+            return -1;
+        }
+
         double actAngle = getVerticalOffset() + camAngle;
         double hDistance = targetHeight / (Math.tan(Math.toRadians(actAngle)));
         


### PR DESCRIPTION
* Changed Limelight transform method to return null if the default
  values were returned from NetworkTables.

* Changed Limelight distance method to return -1 if a target is not
  present.

* Changed the trajectory command generator method in drive system to
  check for null trajectories passed in and replace them with a
  trajectory that doesn't move.